### PR TITLE
There needs to be proper handling of 32/64 bit Python executions

### DIFF
--- a/Source/KqlPython/realtimekql.py
+++ b/Source/KqlPython/realtimekql.py
@@ -1,21 +1,27 @@
-﻿"""A script for viewing and transforming real-time event streams with KQL"""
+"""A script for viewing and transforming real-time event streams with KQL"""
 import os
 import sys
 import traceback
 import json
 import clr
+import struct
 
 # Adding reference C# DLL References
-REAL_TIME_KQL_LIBRARY = os.path.join(os.path.dirname(__file__), 'lib', 'RealTimeKqlLibrary.dll')
-NEWTON_SOFT = os.path.join(os.path.dirname(__file__), 'lib', 'Newtonsoft.Json.dll')
-clr.AddReference(REAL_TIME_KQL_LIBRARY)
-clr.AddReference(NEWTON_SOFT)
 
-# Importing classes from clr
-from RealTimeKqlLibrary import *
-from System.Collections.Generic import Dictionary;
-from System.Reactive.Kql.CustomTypes import KqlOutput;
-from Newtonsoft.Json import JsonConvert;
+calc = struct.calcsize(("P") * 8)
+if calc == "64":
+    REAL_TIME_KQL_LIBRARY = os.path.join(os.path.dirname(__file__), 'lib', 'RealTimeKqlLibrary.dll')
+    NEWTON_SOFT = os.path.join(os.path.dirname(__file__), 'lib', 'Newtonsoft.Json.dll')
+    clr.AddReference(REAL_TIME_KQL_LIBRARY)
+    clr.AddReference(NEWTON_SOFT)
+    # Importing classes from clr
+    from RealTimeKqlLibrary import *
+    from System.Collections.Generic import Dictionary;
+    from System.Reactive.Kql.CustomTypes import KqlOutput;
+    from Newtonsoft.Json import JsonConvert;
+else:
+    print("Error: This Python module must be run with Python 64 bit version")
+    sys.exit()
 
 # ADX output related imports
 import threading

--- a/Source/KqlPython/realtimekql.py
+++ b/Source/KqlPython/realtimekql.py
@@ -9,7 +9,7 @@ import struct
 # Adding reference C# DLL References
 
 calc = struct.calcsize(("P") * 8)
-if calc == "64":
+if calc == 64:
     REAL_TIME_KQL_LIBRARY = os.path.join(os.path.dirname(__file__), 'lib', 'RealTimeKqlLibrary.dll')
     NEWTON_SOFT = os.path.join(os.path.dirname(__file__), 'lib', 'Newtonsoft.Json.dll')
     clr.AddReference(REAL_TIME_KQL_LIBRARY)


### PR DESCRIPTION
Since the python library has a dependency on RealTimeKqlLibrary.dll and this is build in x64, 32 bit Python versions will not be able to find the assembly of the DLL when importing via CLR. Thus you need to error handle this and ensure the user runs a 64bit version of python when using RxKql Python module. 

This pull request uses struct to handle this quickly, there's probably a better method to do this but I just wanted to demonstrate a quick fix. Feel free to use it. 

![image](https://user-images.githubusercontent.com/14184955/144866634-ed6d1cf7-8de8-4594-889d-6be4fab886a9.png)
![image](https://user-images.githubusercontent.com/14184955/144867046-d42033a6-be5a-48a2-9be8-39842ed53330.png)
