### PR TITLE
Fixed python build and runtime issues

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -114,6 +114,7 @@ jobs:
         copy Source/KqlPython/* ${{ runner.temp }}\python\realtimekql
         cd ${{ runner.temp }}\python\realtimekql
         "${{ needs.setup.outputs.tag_name }}" | Out-File -FilePath VERSION.txt -Encoding ASCII -NoNewline
+        'directory = r"${{ runner.temp }}\python\realtimekql"' | Out-File -FilePath kqlpythondir.py -Encoding ASCII -NoNewline
 
     # Build python wheel
     - name: Build Python Wheel Step

--- a/Source/KqlPython/realtimekql.py
+++ b/Source/KqlPython/realtimekql.py
@@ -8,8 +8,10 @@ import clr
 # Adding reference C# DLL References
 REAL_TIME_KQL_LIBRARY = os.path.join(os.path.dirname(__file__), 'lib', 'RealTimeKqlLibrary.dll')
 NEWTON_SOFT = os.path.join(os.path.dirname(__file__), 'lib', 'Newtonsoft.Json.dll')
+RX_KQL = os.path.join(os.path.dirname(__file__), 'lib', 'Rx.Kql.dll')
 clr.AddReference(REAL_TIME_KQL_LIBRARY)
 clr.AddReference(NEWTON_SOFT)
+clr.AddReference(RX_KQL)
 
 # Importing classes from clr
 from RealTimeKqlLibrary import *

--- a/Source/KqlPython/setup.py
+++ b/Source/KqlPython/setup.py
@@ -2,10 +2,12 @@ import os
 import glob
 from setuptools import setup, find_packages
 
-with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'VERSION.txt'), encoding='utf-8') as f:
+import kqlpythondir
+
+with open(os.path.join(kqlpythondir.directory, 'VERSION.txt'), encoding='utf-8') as f:
 	version = f.read()
 
-with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'), encoding='utf-8') as f:
+with open(os.path.join(kqlpythondir.directory, 'README.md'), encoding='utf-8') as f:
 	long_description = f.read()
 
 setup(


### PR DESCRIPTION
- Fixed the failing python build workflow that could not find VERSION.txt
- Fixed the module import runtime error that occurred after switching over to Rx.Kql Nuget package from source code